### PR TITLE
Change targets for uniffi 0.25

### DIFF
--- a/BreezSDKLiquid.podspec
+++ b/BreezSDKLiquid.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
   spec.authors                = { "Breez" => "contact@breez.technology" }
   spec.documentation_url      = "https://sdk-doc.breez.technology"
   spec.source                 = { :git => 'https://github.com/breez/breez-sdk-liquid-swift.git', :tag => spec.version }
-  spec.ios.deployment_target  = "11.0"
+  spec.ios.deployment_target  = "13.0"
   spec.source_files           = [
     "Sources/BreezSDKLiquid/*.swift", 
     "Sources/BreezSDKLiquid/**/*.swift"

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,10 @@ import PackageDescription
 let package = Package(
     name: "bindings-swift",
     platforms: [
-        .macOS(.v12),
-        .iOS(.v11),
+        // Required by uniffi 0.25
+        // Can be reverted to v12/v11 for uniffi 0.27
+        .macOS(.v15),
+        .iOS(.v13),
     ],
     products: [
         .library(name: "BreezSDKLiquid", targets: ["breez_sdk_liquidFFI", "BreezSDKLiquid"]),

--- a/breez_sdk_liquidFFI.podspec
+++ b/breez_sdk_liquidFFI.podspec
@@ -7,6 +7,6 @@ Pod::Spec.new do |spec|
   spec.authors                = { "Breez" => "contact@breez.technology" }
   spec.documentation_url      = "https://sdk-doc.breez.technology"
   spec.source                 = { :http => "https://github.com/breez/breez-sdk-liquid-swift/releases/download/#{spec.version}/breez_sdk_liquidFFI.xcframework.zip" }
-  spec.ios.deployment_target  = "11.0"
+  spec.ios.deployment_target  = "13.0"
   spec.vendored_frameworks    = "breez_sdk_liquidFFI.xcframework"
 end


### PR DESCRIPTION
This PR is to change the target dependencies compatible to support uniffi 0.25. When uniffi-bindgen-go is available for 0.27 we can revert back to supporting the original target dependencies.